### PR TITLE
Rebuild v4.3.0a consistently, update dependency on geos on ppc64le

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     - proj_api.patch  # [win]
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win and vc<14]
   run_exports:
     # No idea.  Staying with minor version pin.


### PR DESCRIPTION
We have version 4.3.0a integrated on all platforms, but build numbers are not aligned and on ppc64le it depends on an older version of geos, whereas in cbc.yaml we have a pin on geos=4.8. Rebuild to remove that inconsistency.